### PR TITLE
♻️ css 제안

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "jsxSingleQuote": false,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "plugins": ["prettier-plugin-tailwindcss"],
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "knip": "5.30.6",
     "postcss": "8.4.47",
     "prettier": "3.3.3",
+    "prettier-plugin-tailwindcss": "0.6.9",
     "tailwindcss": "3.4.13",
     "typescript": "5.6.2",
     "vite": "5.4.8"

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -19,7 +19,7 @@ export const Button = ({
 }: Props) => {
   const backgroundClassName =
     variant === 'contained'
-      ? `w-[311px] h-[41px] p-3 rounded-[6px] gap-1 flex items-center justify-center disabled:bg-grey-disabled ${colorMap[color].bg}`
+      ? `h-[41px] p-3 rounded-[6px] gap-1 flex items-center justify-center disabled:bg-grey-disabled ${colorMap[color].bg}`
       : '';
 
   const textClassName = `font-pretendard text-[14px] font-bold ${colorMap[color].text} leading-[16.71px] text-left`;

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -10,7 +10,7 @@ import { IcTimeTable } from '../icons/ic-time-table';
 export const Navigation = () => {
   const navigation = useNavigate();
   return (
-    <div className="w-full flex justify-between pt-[10px] pb-[44px] pl-[30px] pr-[30px] border-t">
+    <div className="flex justify-between border-t px-[30px] py-2.5">
       <IconWrapper
         onClick={() => {
           navigation('/');
@@ -49,7 +49,7 @@ const IconWrapper = ({ children, onClick }: IconWrapperProps) => {
   };
   return (
     <div
-      className="w-[30px] h-[30px] flex justify-center items-center cursor-pointer"
+      className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center"
       onClick={handleOnClick}
     >
       {children}

--- a/src/views/AuthenticatedPage.tsx
+++ b/src/views/AuthenticatedPage.tsx
@@ -4,8 +4,10 @@ import { Navigation } from '../components/navigation';
 
 export const AuthenticatedPage = () => {
   return (
-    <div className="overflow-auto flex flex-col justify-center h-dvh px-2">
-      <Outlet />
+    <div className="flex h-dvh flex-col">
+      <div className="flex flex-1 flex-col">
+        <Outlet />
+      </div>
       <Navigation />
     </div>
   );

--- a/src/views/Landing.tsx
+++ b/src/views/Landing.tsx
@@ -11,15 +11,15 @@ export const Landing = () => {
   };
 
   return (
-    <div className="mt-69">
-      <div className="flex flex-col justify-center items-center gap-4">
+    <div className="flex h-dvh flex-col justify-center">
+      <div className="flex flex-col items-center gap-4">
         <img src="/logo/waffle.jpeg" width="60px" height="60px" />
-        <div className="font-sf-pro text=[21.35px] font-[860] leading-[25.48px] text-center">
+        <div className="text=[21.35px] text-center font-sf-pro font-[860] leading-[25.48px]">
           TimeTable
         </div>
       </div>
-      <div className="mt-34 flex flex-col justify-center items-center gap-10">
-        <div className="flex flex-col items-center justify-center gap-[14px]">
+      <div className="mt-34 flex flex-col justify-center gap-10">
+        <div className="flex flex-col gap-3.5 px-10">
           <Button
             onClick={handleOnClickLogin}
             variant="contained"
@@ -27,19 +27,21 @@ export const Landing = () => {
           >
             로그인
           </Button>
-          <Button variant="text" color="white">
-            회원가입
-          </Button>
+          <div className="flex justify-center">
+            <Button variant="text" color="white">
+              회원가입
+            </Button>
+          </div>
         </div>
-        <div className="flex flex-col items-center justify-center gap-6">
-          <div className="flex items-center gap-[10px]">
-            <Divider className="w-25" />
-            <div className="font-pretendard font-[500] text-grey-assistive leading-[16.71px] text-[14px]">
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-[10px] px-5">
+            <Divider className="flex-1" />
+            <div className="font-pretendard text-[14px] font-[500] leading-[16.71px] text-grey-assistive">
               SNS 계정으로 계속하기
             </div>
-            <Divider className="w-25" />
+            <Divider className="flex-1" />
           </div>
-          <div className="flex gap-3">
+          <div className="flex justify-center gap-3">
             <SocialLoginButton src="/logo/kakao.png" alt="kakaoLogin" />
             <SocialLoginButton
               src="/logo/google.png"
@@ -75,7 +77,7 @@ const SocialLoginButton = ({
     <img
       src={src}
       alt={alt}
-      className={`w-[44px] h-[44px] rounded-full object-cover cursor-pointer ${borderClass} ${className}`}
+      className={`h-11 w-11 cursor-pointer rounded-full object-cover ${borderClass} ${className}`}
     />
   );
 };

--- a/src/views/LectureDetail.tsx
+++ b/src/views/LectureDetail.tsx
@@ -29,53 +29,53 @@ export const LectureDetail = () => {
   };
 
   return (
-    <div className="flex flex-col justify-start h-screen bg-grey-background gap-1 font-pretendard">
+    <div className="flex flex-1 flex-col gap-1 bg-grey-background font-pretendard">
       <Header />
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">강의명</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">강의명</div>
         <div>{lecture.course_title}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">교수명</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">교수명</div>
         <div>{lecture.instructor}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">학과</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">학과</div>
         <div>{lecture.department}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">학점</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">학점</div>
         <div>{lecture.credit}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">분류</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">분류</div>
         <div>
           {lecture.classification !== '' ? lecture.classification : '(없음)'}
         </div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">구분</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">구분</div>
         <div>{lecture.category !== '' ? lecture.category : '(없음)'}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">강좌번호</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">강좌번호</div>
         <div>{lecture.course_number}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">분반 번호</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">분반 번호</div>
         <div>{lecture.lecture_number}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">정원</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">정원</div>
         <div>{lecture.quota}</div>
       </div>
-      <div className="w-full bg-white px-4 py-2 flex gap-4 items-center">
-        <div className="w-20 text-gray-400 text-sm">비고</div>
+      <div className="flex items-center gap-4 bg-white px-4 py-2">
+        <div className="w-20 text-sm text-gray-400">비고</div>
         <div>{lecture.remark}</div>
       </div>
       <button
         onClick={handleOnClick}
-        className="w-full text-red bg-white p-2 rounded-[6px]"
+        className="rounded-md bg-white p-2 text-red"
       >
         삭제
       </button>
@@ -90,14 +90,12 @@ const Header = () => {
   };
 
   return (
-    <div className="w-[375px] flex items-center justify-between p-2">
-      <div
-        onClick={handleOnClick}
-        className="flex items-center gap-1 cursor-pointer"
-      >
-        <IcArrowBack className="text-black" />
-        <div className="font-[500]">강의 상세 보기</div>
-      </div>
+    <div
+      onClick={handleOnClick}
+      className="flex cursor-pointer items-center gap-1 p-2"
+    >
+      <IcArrowBack className="text-black" />
+      <div className="font-[500]">강의 상세 보기</div>
     </div>
   );
 };

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -9,9 +9,9 @@ import { useUnauthenticatedServiceContext } from '../contexts/unauthenticatedSer
 
 export const Login = () => {
   return (
-    <div className="flex flex-col justify-center items-center font-pretendard">
+    <div className="flex flex-1 flex-col font-pretendard">
       <ActionBar />
-      <Divider className="w-[375px]" />
+      <Divider />
       <LoginForm />
     </div>
   );
@@ -24,17 +24,15 @@ const ActionBar = () => {
   };
 
   return (
-    <div className="w-[375px] flex items-center justify-between p-2">
+    <div className="grid grid-cols-3 p-2">
       <div
         onClick={handleOnClick}
-        className="flex items-center gap-1 cursor-pointer"
+        className="flex cursor-pointer items-center gap-1"
       >
         <IcArrowBack className="text-black" />
         <div className="font-[500]">뒤로</div>
       </div>
-      <div className="absolute left-1/2 transform -translate-x-1/2 font-bold">
-        로그인
-      </div>
+      <div className="text-center font-bold">로그인</div>
     </div>
   );
 };
@@ -81,7 +79,7 @@ const LoginForm = () => {
 
   return (
     <form
-      className="p-4"
+      className="flex flex-col p-4"
       onSubmit={(e) => {
         handleSubmit(e);
       }}
@@ -102,13 +100,13 @@ const LoginForm = () => {
           required
         />
       </div>
-      <Divider className="w-[311px] mb-2 mt-2" />
+      <Divider className="my-2" />
       <div className="flex flex-col gap-2">
         <label htmlFor="password" className="text-dark-grey">
           비밀번호
         </label>
         <input
-          className="focus:outline-none"
+          className="outline-none"
           type="password"
           id="password"
           value={loginInput.password}
@@ -119,7 +117,7 @@ const LoginForm = () => {
           required
         />
       </div>
-      <Divider className="w-[311px] mb-2 mt-2" />
+      <Divider className="my-2" />
       <Button color="mint" variant="contained" disabled={disabled}>
         로그인
       </Button>

--- a/src/views/MyPage.tsx
+++ b/src/views/MyPage.tsx
@@ -10,7 +10,7 @@ import type { User } from '../entities/user';
 
 export const MyPage = () => {
   return (
-    <div className="flex flex-col justify-start h-screen bg-grey-background gap-2 font-pretendard">
+    <div className="flex flex-1 flex-col gap-2 bg-grey-background font-pretendard">
       <MyPageHeader />
       <MyAccount />
       <Logout />
@@ -20,8 +20,8 @@ export const MyPage = () => {
 
 const MyPageHeader = () => {
   return (
-    <div className="w-full bg-white p-2">
-      <div className="flex justify-cstart items-center gap-2">
+    <div className="bg-white p-2">
+      <div className="flex items-center gap-2">
         <IcSeeMore />
         <div className="font-bold">더보기</div>
       </div>
@@ -31,7 +31,7 @@ const MyPageHeader = () => {
 
 const MyAccountLabel = () => {
   return (
-    <div className="flex items-center text-[13px] gap-1">
+    <div className="flex items-center gap-1 text-[13px]">
       <IcUserFilled width="15" className="text-grey-assistive" />
       <div>내 계정</div>
     </div>
@@ -40,7 +40,7 @@ const MyAccountLabel = () => {
 
 const MyAccount = () => {
   return (
-    <div className="w-full bg-white p-4 flex justify-between">
+    <div className="flex justify-between bg-white p-4">
       <MyAccountLabel />
       <MyNickname />
     </div>
@@ -90,15 +90,15 @@ const MyNickname = () => {
     <div className="flex items-center gap-1">
       {state.loading ? (
         // Loading spinner
-        <div className="flex justify-center items-center space-x-2">
-          <div className="w-4 h-4 border-2 border-dashed rounded-full animate-spin border-mint-500"></div>
+        <div className="flex items-center justify-center space-x-2">
+          <div className="border-mint-500 h-4 w-4 animate-spin rounded-full border-2 border-dashed"></div>
           <div className="text-[13px] font-semibold text-gray-500">
             로딩 중...
           </div>
         </div>
       ) : state.error !== null ? (
         // Error message
-        <div className="text-center text-red-500 text-lg font-bold">
+        <div className="text-red-500 text-center text-lg font-bold">
           {state.error}
         </div>
       ) : state.user !== null ? (
@@ -108,7 +108,7 @@ const MyNickname = () => {
         </div>
       ) : (
         // Failed
-        <div className="text-center text-red-500 text-[13px] font-bold">
+        <div className="text-red-500 text-center text-[13px] font-bold">
           유저 불러오기 실패!
         </div>
       )}
@@ -131,12 +131,12 @@ const Logout = () => {
     navigate('/');
   };
   return (
-    <div
-      className="bg-white w-full p-2 pl-4 pr-4 text-red text-[13px] flex justify-between items-center cursor-pointer"
+    <button
+      className="flex cursor-pointer items-center justify-between bg-white py-2 pl-4 pr-4 text-[13px] text-red"
       onClick={handleOnClick}
     >
       <div>로그아웃</div>
       <IcChevronRight width="12" className="text-black" />
-    </div>
+    </button>
   );
 };

--- a/src/views/TimeTable.tsx
+++ b/src/views/TimeTable.tsx
@@ -39,9 +39,10 @@ export const Timetable = () => {
 
   return (
     <>
-      <div className="flex pt-2 pr-3 pb-1.5 pl-4 gap-2.5 items-center justify-between">
-        <div className="flex items-center gap-2">
-          <IcListView />
+      <div className="flex items-center gap-3 pb-1.5 pl-4 pr-3 pt-2">
+        <IcListView />
+
+        <div className="flex flex-1 items-center gap-2">
           <div className="text-base font-bold">
             {timetable?.title ?? '로딩 중..'}
           </div>
@@ -53,6 +54,7 @@ export const Timetable = () => {
             학점)
           </div>
         </div>
+
         <IcList
           className="cursor-pointer"
           onClick={() => {
@@ -61,18 +63,18 @@ export const Timetable = () => {
         />
       </div>
       <div
-        className="grid h-full"
+        className="grid flex-1"
         style={{
           gridTemplateRows: `30px repeat(${HOUR_LIST.length * MINUTE_LEN}, 1fr)`,
           gridTemplateColumns: `10vw repeat(${DAY_LIST.length}, 1fr)`,
         }}
       >
         {/* header */}
-        <div className="row-start-1 row-end-2 col-start-1 col-end-2"></div>
+        <div className="col-start-1 col-end-2 row-start-1 row-end-2"></div>
         {DAY_LIST.map((day) => (
           <div
             key={day}
-            className="flex justify-center items-center text-sm text-center text-dark-grey font-semibold border-l"
+            className="flex items-center justify-center border-l text-sm font-semibold text-dark-grey"
             style={{
               gridColumnStart: day + 2,
               gridColumnEnd: day + 3,
@@ -85,7 +87,7 @@ export const Timetable = () => {
         {/* time */}
         {HOUR_LIST.map((hour, index) => (
           <div
-            className="col-start-1 col-end-2 text-right pr-1 text-dark-grey border-t"
+            className="col-start-1 col-end-2 border-t pr-1 text-right text-dark-grey"
             style={{
               gridRowStart: index * MINUTE_LEN + 2,
               gridRowEnd: index * MINUTE_LEN + MINUTE_LEN + 2,
@@ -99,14 +101,14 @@ export const Timetable = () => {
         {timetable?.lecture_list.map((l) =>
           l.class_time_json.map((c) => (
             <div
-              className={`${COLOR_MAP[l.color_index] ?? 'bg-black'} text-white px-1.5 flex flex-col gap-0.5 justify-center items-center text-center z-10 overflow-hidden`}
+              className={`${COLOR_MAP[l.color_index] ?? 'bg-black'} z-10 flex flex-col items-center justify-center gap-0.5 overflow-hidden px-1.5 text-center text-white`}
               key={`${c.day}-${c.start_time}-${c.end_time}`}
               style={convertToGridState(c.day, c.start_time, c.end_time)}
               onClick={() => {
                 handleOnClick(timetable._id, l);
               }}
             >
-              <div className="text-xxsm text-ellipis overflow-hidden max-h-6">
+              <div className="text-ellipis max-h-6 overflow-hidden text-xxsm">
                 {l.course_title}
               </div>
               <div className="text-xsm font-semibold">{c.place}</div>
@@ -119,7 +121,7 @@ export const Timetable = () => {
           HOUR_LIST.map((_, indexRow) => (
             <>
               <div
-                className="border-t border-l"
+                className="border-l border-t"
                 style={{
                   gridRowStart: MINUTE_LEN * indexRow + 2,
                   gridRowEnd: MINUTE_LEN * indexRow + MINUTE_HALFLEN + 2,
@@ -128,7 +130,7 @@ export const Timetable = () => {
                 }}
               ></div>
               <div
-                className="border-t border-l border-t-gray-100"
+                className="border-l border-t border-t-gray-100"
                 style={{
                   gridRowStart: MINUTE_LEN * indexRow + MINUTE_HALFLEN + 2,
                   gridRowEnd: MINUTE_LEN * (indexRow + 1) + 2,

--- a/src/views/TimeTableList.tsx
+++ b/src/views/TimeTableList.tsx
@@ -29,10 +29,11 @@ export const TimeTableList = () => {
       .catch(() => null);
   }, [timetableService]);
   return (
-    <div className="flex-1">
+    <div>
       <TimeTableListHeader timetable={timetable} />
       {timetable?.lecture_list.map((lecture, index) => (
         <div
+          className="p-2"
           key={index}
           onClick={() => {
             handleOnClick(timetable._id, lecture);
@@ -52,9 +53,9 @@ type TimeTableListHeaderProps = {
 const TimeTableListHeader = ({ timetable }: TimeTableListHeaderProps) => {
   const navigate = useNavigate();
   return (
-    <div className="w-full bg-white p-2">
-      <div
-        className="flex justify-cstart items-center gap-2 cursor-pointer"
+    <div className="bg-white p-2">
+      <button
+        className="flex cursor-pointer items-center gap-2"
         onClick={() => {
           navigate('/');
         }}
@@ -65,7 +66,7 @@ const TimeTableListHeader = ({ timetable }: TimeTableListHeaderProps) => {
         ) : (
           <div className="font-bold">로딩 중..</div>
         )}
-      </div>
+      </button>
     </div>
   );
 };
@@ -76,14 +77,14 @@ type LectureItemProps = {
 
 const LectureItem = ({ lecture }: LectureItemProps) => {
   return (
-    <div className="m-2">
+    <div>
       <div className="flex justify-between">
-        <div className="font-bold text-[14px]">{lecture.course_title}</div>
+        <div className="text-[14px] font-bold">{lecture.course_title}</div>
         <div className="text-[13px]">
           {lecture.instructor} / {lecture.credit}학점
         </div>
       </div>
-      <div className="m-1">
+      <div className="p-1">
         <div className="flex items-center gap-2">
           <IcTag width="12px" />
           <div className="text-[12px]">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-plugin-tailwindcss@npm:0.6.9":
+  version: 0.6.9
+  resolution: "prettier-plugin-tailwindcss@npm:0.6.9"
+  peerDependencies:
+    "@ianvs/prettier-plugin-sort-imports": "*"
+    "@prettier/plugin-pug": "*"
+    "@shopify/prettier-plugin-liquid": "*"
+    "@trivago/prettier-plugin-sort-imports": "*"
+    "@zackad/prettier-plugin-twig-melody": "*"
+    prettier: ^3.0
+    prettier-plugin-astro: "*"
+    prettier-plugin-css-order: "*"
+    prettier-plugin-import-sort: "*"
+    prettier-plugin-jsdoc: "*"
+    prettier-plugin-marko: "*"
+    prettier-plugin-multiline-arrays: "*"
+    prettier-plugin-organize-attributes: "*"
+    prettier-plugin-organize-imports: "*"
+    prettier-plugin-sort-imports: "*"
+    prettier-plugin-style-order: "*"
+    prettier-plugin-svelte: "*"
+  peerDependenciesMeta:
+    "@ianvs/prettier-plugin-sort-imports":
+      optional: true
+    "@prettier/plugin-pug":
+      optional: true
+    "@shopify/prettier-plugin-liquid":
+      optional: true
+    "@trivago/prettier-plugin-sort-imports":
+      optional: true
+    "@zackad/prettier-plugin-twig-melody":
+      optional: true
+    prettier-plugin-astro:
+      optional: true
+    prettier-plugin-css-order:
+      optional: true
+    prettier-plugin-import-sort:
+      optional: true
+    prettier-plugin-jsdoc:
+      optional: true
+    prettier-plugin-marko:
+      optional: true
+    prettier-plugin-multiline-arrays:
+      optional: true
+    prettier-plugin-organize-attributes:
+      optional: true
+    prettier-plugin-organize-imports:
+      optional: true
+    prettier-plugin-sort-imports:
+      optional: true
+    prettier-plugin-style-order:
+      optional: true
+    prettier-plugin-svelte:
+      optional: true
+  checksum: 10c0/370b1d67063a6ff15b0b7fd5d6687bef587aa4be0c856e7f743d5016037ff25d0d69c6aa8c6cecf1355676962aeca52089dc28d063540fb030bcd326a07f47f8
+  languageName: node
+  linkType: hard
+
 "prettier@npm:3.3.3":
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
@@ -3696,6 +3754,7 @@ __metadata:
     knip: "npm:5.30.6"
     postcss: "npm:8.4.47"
     prettier: "npm:3.3.3"
+    prettier-plugin-tailwindcss: "npm:0.6.9"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.27.0"


### PR DESCRIPTION
1. 일단 `prettier-plugin-tailwindcss` 설치했습니다. 이거 없으면 너무 더러워서..
2. 전체적으로 `w-full` 이나 `w-[311px]` 처럼 컨테이너 너비를 지정해주는 코드들이 있었는데, 일단 `w-[311px]` 같은 건 사실 너비 스펙이 아니라 여백을 고정해야 하는 스펙이기 때문에 모두 좌우 마진/패딩으로 대체했습니다. 또한 `w-full` 의 경우 div 는 기본적으로 너비가 100% 이고 flex 컨테이너 내에서는 굳이 필요없어서 모두 없앴습니다. 보통 `w-full` `h-full` 이런 게 필요한 경우는 거의 없는 것 같아요!
3. `h-screen` 도 전역적으로 한 번만 해 주면 될 것 같아서 AuthenticatedPage 랑 Landing 각각에 `h-dvh` 먹여줬습니다.
4. css랑은 무관한데, onClick 이 있으면 `div` 가 아니라 `button` 태그인 게 좋습니다! (접근성 측면)